### PR TITLE
GET requests using the magic method are sent as POST requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,11 @@ const Plugin = function (Alpine) {
         })
         Alpine.magic(type.directive, (el, { evaluate }) => expression =>{
             let data = evalExpression(expression, evaluate);
-            processRequest({el, ...data});
+            processRequest({
+                el,
+                method: type.method,
+                ...data
+            });
         })
     });
 


### PR DESCRIPTION
The method parameter was missing from the magic method definition, so it was defaulting to POST.

Adding the method parameter allows GET requests to be sent correctly.

Example:

    <input type="text" x-model="email" x-on:keyup.debounce="$get('/api/check-email?email=' + email);" @get="emailFound = $event.detail.response.json()" required />